### PR TITLE
Modification for newer Version of Sketch

### DIFF
--- a/dist/blade.sketchplugin
+++ b/dist/blade.sketchplugin
@@ -1773,7 +1773,7 @@ Binding.registry('width',{
 function export_as_img( layer, filename ){
   // Actual writing of asset
   var slice,
-    rect = [layer rectByAccountingForStyleSize:[[layer absoluteRect] rect]]
+    rect = [layer absoluteDirtyRect]
 
 
   slice = [[MSSliceMaker slicesFromExportableLayer:layer inRect:rect] firstObject]

--- a/src/foot.js
+++ b/src/foot.js
@@ -4,7 +4,7 @@
 function export_as_img( layer, filename ){
   // Actual writing of asset
   var slice,
-    rect = [layer rectByAccountingForStyleSize:[[layer absoluteRect] rect]]
+    rect = [layer absoluteDirtyRect]
 
 
   slice = [[MSSliceMaker slicesFromExportableLayer:layer inRect:rect] firstObject]


### PR DESCRIPTION
This patch is needed for basic working in Sketch Version 3.2.2 (9983).

It Converts the API function 'rectByAccountingForStyleSize' to 'absoluteDirtyRect'.

After the change, the plugin will output HTML from the provided sample. The input element and the link works, but the cart won't work. This will need more testing/fixing…